### PR TITLE
[feature] update sensitivity to self-passive

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -24,6 +24,7 @@ type RunOptions struct {
 	Env          map[string]string
 	DryRun       bool
 	StreamOutput bool
+	LoggerPrefix string
 	LoggerArgs   []any
 }
 
@@ -31,7 +32,7 @@ type RunOptions struct {
 // Note: This function never times out - commands can take an indeterminate amount of time
 // (e.g., failover commands that may need to wait for services to start/stop).
 func Run(opts RunOptions) error {
-	logger := log.WithPrefix(fmt.Sprintf("command[%s]", opts.Name))
+	logger := log.WithPrefix(fmt.Sprintf("[%s command %s]", opts.LoggerPrefix, opts.Name))
 	envString := ""
 	for key, value := range opts.Env {
 		envString += fmt.Sprintf("%s=%s ", key, value)

--- a/internal/config/role.go
+++ b/internal/config/role.go
@@ -27,8 +27,9 @@ type Role struct {
 }
 
 type RoleCommandRunOptions struct {
-	DryRun     bool
-	LoggerArgs []any
+	DryRun       bool
+	LoggerPrefix string
+	LoggerArgs   []any
 }
 
 // Validate validates the role configuration
@@ -145,6 +146,7 @@ func (r *Role) RunCommand(opts RoleCommandRunOptions) error {
 		Args:         r.Args,
 		Env:          r.Env,
 		DryRun:       opts.DryRun,
+		LoggerPrefix: opts.LoggerPrefix,
 		LoggerArgs:   loggerArgs,
 		StreamOutput: true,
 	})

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -1,0 +1,25 @@
+package constants
+
+const (
+	// RoleNameActive is the name of the active role
+	RoleNameActive = "active"
+	// RoleNamePassive is the name of the passive role
+	RoleNamePassive = "passive"
+	// RoleNameUnknown is the name of the unknown role
+	RoleNameUnknown = "unknown"
+
+	// StatusHealthy is the name of the healthy status
+	StatusHealthy = "healthy"
+	// StatusUnhealthy is the name of the unhealthy status
+	StatusUnhealthy = "unhealthy"
+	// StatusIdle is the name of the idle status
+	StatusIdle = "idle"
+	// StatusBecomingActive is the name of the becoming active status
+	StatusBecomingActive = "becoming_active"
+	// StatusBecomingPassive is the name of the becoming passive status
+	StatusBecomingPassive = "becoming_passive"
+	// HookTypePre is the name of the pre hook type
+	HookTypePre = "pre"
+	// HookTypePost is the name of the post hook type
+	HookTypePost = "post"
+)

--- a/internal/gossip/state_test.go
+++ b/internal/gossip/state_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestNewState(t *testing.T) {
 	// Create a real RPC client for this test since we're not testing RPC functionality
-	realRPC := rpc.NewClient("https://api.mainnet-beta.solana.com")
+	realRPC := rpc.NewClient("test", "https://api.mainnet-beta.solana.com")
 
 	opts := Options{
 		ClusterRPC:   realRPC,
@@ -34,7 +34,7 @@ func TestNewState(t *testing.T) {
 }
 
 func TestHasIP(t *testing.T) {
-	realRPC := rpc.NewClient("https://api.mainnet-beta.solana.com")
+	realRPC := rpc.NewClient("test", "https://api.mainnet-beta.solana.com")
 
 	opts := Options{
 		ClusterRPC:   realRPC,
@@ -60,7 +60,7 @@ func TestHasIP(t *testing.T) {
 }
 
 func TestHasActivePeer(t *testing.T) {
-	realRPC := rpc.NewClient("https://api.mainnet-beta.solana.com")
+	realRPC := rpc.NewClient("test", "https://api.mainnet-beta.solana.com")
 
 	opts := Options{
 		ClusterRPC:   realRPC,
@@ -91,7 +91,7 @@ func TestHasActivePeer(t *testing.T) {
 }
 
 func TestHasActivePeerInTheLastNSamples(t *testing.T) {
-	realRPC := rpc.NewClient("https://api.mainnet-beta.solana.com")
+	realRPC := rpc.NewClient("test", "https://api.mainnet-beta.solana.com")
 
 	opts := Options{
 		ClusterRPC:   realRPC,
@@ -106,13 +106,13 @@ func TestHasActivePeerInTheLastNSamples(t *testing.T) {
 	state.peerStatesByName = map[string]PeerState{
 		"peer1": {IP: "192.168.1.2", Pubkey: "pubkey1", LastSeenAtUTC: time.Now().UTC(), LastSeenActive: false},
 	}
-	state.leaderlessSamplesCount = 5 // Set count to 5
+	state.LeaderlessSamplesCount = 5 // Set count to 5
 
 	// With threshold of 3, count of 5 should fail (5 >= 3)
-	assert.False(t, state.HasActivePeerInTheLastNSamples(3))
+	assert.False(t, state.LeaderlessSamplesBelowThreshold(3))
 
 	// With threshold of 10, count of 5 should pass (5 < 10)
-	assert.True(t, state.HasActivePeerInTheLastNSamples(10))
+	assert.True(t, state.LeaderlessSamplesBelowThreshold(10))
 
 	// Test with active peer found (leaderlessSamplesCount should be reset)
 	state.peerStatesByName["peer2"] = PeerState{
@@ -121,19 +121,19 @@ func TestHasActivePeerInTheLastNSamples(t *testing.T) {
 		LastSeenAtUTC:  time.Now().UTC(),
 		LastSeenActive: true,
 	}
-	state.leaderlessSamplesCount = 0 // Reset count when active peer found
+	state.LeaderlessSamplesCount = 0 // Reset count when active peer found
 
 	// With threshold of 3, count of 0 should pass (0 < 3)
-	assert.True(t, state.HasActivePeerInTheLastNSamples(3))
+	assert.True(t, state.LeaderlessSamplesBelowThreshold(3))
 
 	// Test with count at threshold boundary
-	state.leaderlessSamplesCount = 3
-	assert.False(t, state.HasActivePeerInTheLastNSamples(3)) // 3 >= 3, should fail
-	assert.True(t, state.HasActivePeerInTheLastNSamples(4))  // 3 < 4, should pass
+	state.LeaderlessSamplesCount = 3
+	assert.False(t, state.LeaderlessSamplesBelowThreshold(3)) // 3 >= 3, should fail
+	assert.True(t, state.LeaderlessSamplesBelowThreshold(4))  // 3 < 4, should pass
 }
 
 func TestGetActivePeer(t *testing.T) {
-	realRPC := rpc.NewClient("https://api.mainnet-beta.solana.com")
+	realRPC := rpc.NewClient("test", "https://api.mainnet-beta.solana.com")
 
 	opts := Options{
 		ClusterRPC:   realRPC,
@@ -166,7 +166,7 @@ func TestGetActivePeer(t *testing.T) {
 }
 
 func TestHasPeers(t *testing.T) {
-	realRPC := rpc.NewClient("https://api.mainnet-beta.solana.com")
+	realRPC := rpc.NewClient("test", "https://api.mainnet-beta.solana.com")
 
 	opts := Options{
 		ClusterRPC:   realRPC,
@@ -200,7 +200,7 @@ func TestHasPeers(t *testing.T) {
 }
 
 func TestGetPeerStates(t *testing.T) {
-	realRPC := rpc.NewClient("https://api.mainnet-beta.solana.com")
+	realRPC := rpc.NewClient("test", "https://api.mainnet-beta.solana.com")
 
 	opts := Options{
 		ClusterRPC:   realRPC,
@@ -242,7 +242,7 @@ func TestPeerState_LastSeenAtString(t *testing.T) {
 func TestRefresh_WithRPCError(t *testing.T) {
 	// Test that Refresh handles RPC errors gracefully
 	// We'll use a real RPC client but with an invalid URL to simulate failure
-	invalidRPC := rpc.NewClient("https://invalid-url-that-will-fail.com")
+	invalidRPC := rpc.NewClient("test", "https://invalid-url-that-will-fail.com")
 
 	opts := Options{
 		ClusterRPC:   invalidRPC,
@@ -271,7 +271,7 @@ func TestRefresh_WithRPCError(t *testing.T) {
 func TestRefresh_WithValidRPC(t *testing.T) {
 	// Test Refresh with a valid RPC client
 	// This test may fail if the RPC endpoint is not available, but that's expected
-	realRPC := rpc.NewClient("https://api.mainnet-beta.solana.com")
+	realRPC := rpc.NewClient("test", "https://api.mainnet-beta.solana.com")
 
 	opts := Options{
 		ClusterRPC:   realRPC,
@@ -295,7 +295,7 @@ func TestRefresh_WithValidRPC(t *testing.T) {
 }
 
 func TestState_EdgeCases(t *testing.T) {
-	realRPC := rpc.NewClient("https://api.mainnet-beta.solana.com")
+	realRPC := rpc.NewClient("test", "https://api.mainnet-beta.solana.com")
 
 	opts := Options{
 		ClusterRPC:   realRPC,
@@ -322,7 +322,7 @@ func TestState_EdgeCases(t *testing.T) {
 }
 
 func TestState_EmptyConfigPeers(t *testing.T) {
-	realRPC := rpc.NewClient("https://api.mainnet-beta.solana.com")
+	realRPC := rpc.NewClient("test", "https://api.mainnet-beta.solana.com")
 
 	opts := Options{
 		ClusterRPC:   realRPC,
@@ -335,8 +335,8 @@ func TestState_EmptyConfigPeers(t *testing.T) {
 
 	// Test all methods with empty config
 	assert.False(t, state.HasActivePeer())
-	state.leaderlessSamplesCount = 5 // Set count high
-	assert.False(t, state.HasActivePeerInTheLastNSamples(3))
+	state.LeaderlessSamplesCount = 5 // Set count high
+	assert.False(t, state.LeaderlessSamplesBelowThreshold(3))
 	assert.False(t, state.HasIP("192.168.1.1"))
 	assert.False(t, state.HasPeers("192.168.1.1"))
 
@@ -348,7 +348,7 @@ func TestState_EmptyConfigPeers(t *testing.T) {
 }
 
 func TestState_SampleBasedLogic(t *testing.T) {
-	realRPC := rpc.NewClient("https://api.mainnet-beta.solana.com")
+	realRPC := rpc.NewClient("test", "https://api.mainnet-beta.solana.com")
 
 	opts := Options{
 		ClusterRPC:   realRPC,
@@ -369,27 +369,27 @@ func TestState_SampleBasedLogic(t *testing.T) {
 			LastSeenActive: true,
 		},
 	}
-	state.leaderlessSamplesCount = 0 // Reset when active peer found
+	state.LeaderlessSamplesCount = 0 // Reset when active peer found
 
 	// Should pass with threshold of 3 (0 < 3)
-	assert.True(t, state.HasActivePeerInTheLastNSamples(3))
+	assert.True(t, state.LeaderlessSamplesBelowThreshold(3))
 
 	// Should pass with threshold of 1 (0 < 1)
-	assert.True(t, state.HasActivePeerInTheLastNSamples(1))
+	assert.True(t, state.LeaderlessSamplesBelowThreshold(1))
 
-	// Test with no active peer (leaderlessSamplesCount increments)
-	state.leaderlessSamplesCount = 5
+	// Test with no active peer (LeaderlessSamplesCount increments)
+	state.LeaderlessSamplesCount = 5
 	delete(state.peerStatesByName, "peer1") // Remove active peer
 
 	// Should fail with threshold of 3 (5 >= 3)
-	assert.False(t, state.HasActivePeerInTheLastNSamples(3))
+	assert.False(t, state.LeaderlessSamplesBelowThreshold(3))
 
 	// Should pass with threshold of 10 (5 < 10)
-	assert.True(t, state.HasActivePeerInTheLastNSamples(10))
+	assert.True(t, state.LeaderlessSamplesBelowThreshold(10))
 }
 
 func TestState_ConcurrentAccess(t *testing.T) {
-	realRPC := rpc.NewClient("https://api.mainnet-beta.solana.com")
+	realRPC := rpc.NewClient("test", "https://api.mainnet-beta.solana.com")
 
 	opts := Options{
 		ClusterRPC:   realRPC,

--- a/internal/rpc/clients_test.go
+++ b/internal/rpc/clients_test.go
@@ -121,7 +121,7 @@ func mockSlowServer(t *testing.T, delay time.Duration) *httptest.Server {
 
 func TestNewClient(t *testing.T) {
 	// Test creating client with multiple URLs
-	client := NewClient("http://localhost:8899", "https://api.testnet.solana.com")
+	client := NewClient("test", "http://localhost:8899", "https://api.testnet.solana.com")
 
 	assert.NotNil(t, client)
 	assert.Len(t, client.clients, 2)
@@ -153,7 +153,7 @@ func TestGetClusterNodes(t *testing.T) {
 		"getClusterNodes": mockResponse,
 	})
 
-	client := NewClient(server.URL)
+	client := NewClient("test", server.URL)
 	ctx := context.Background()
 
 	result, err := client.GetClusterNodes(ctx)
@@ -185,7 +185,7 @@ func TestGetIdentity(t *testing.T) {
 		"getIdentity": mockResponse,
 	})
 
-	client := NewClient(server.URL)
+	client := NewClient("test", server.URL)
 	ctx := context.Background()
 
 	result, err := client.GetIdentity(ctx)
@@ -201,7 +201,7 @@ func TestGetHealth(t *testing.T) {
 		"getHealth": mockResponse,
 	})
 
-	client := NewClient(server.URL)
+	client := NewClient("test", server.URL)
 	ctx := context.Background()
 
 	result, err := client.GetHealth(ctx)
@@ -221,7 +221,7 @@ func TestRetryLogic(t *testing.T) {
 	})
 
 	// Create client with failing server first, then working server
-	client := NewClient(failingServer.URL, workingServer.URL)
+	client := NewClient("test", failingServer.URL, workingServer.URL)
 	ctx := context.Background()
 
 	// Should succeed by retrying to the working server
@@ -235,7 +235,7 @@ func TestAllEndpointsFail(t *testing.T) {
 	failingServer1 := mockFailingServer(t)
 	failingServer2 := mockFailingServer(t)
 
-	client := NewClient(failingServer1.URL, failingServer2.URL)
+	client := NewClient("test", failingServer1.URL, failingServer2.URL)
 	ctx := context.Background()
 
 	// Should fail when all endpoints fail
@@ -250,7 +250,7 @@ func TestTimeout(t *testing.T) {
 	// Create a slow server that takes longer than the timeout
 	slowServer := mockSlowServer(t, 10*time.Second)
 
-	client := NewClient(slowServer.URL)
+	client := NewClient("test", slowServer.URL)
 	ctx := context.Background()
 
 	// Should timeout
@@ -264,7 +264,7 @@ func TestCustomTimeout(t *testing.T) {
 	// Create a slow server
 	slowServer := mockSlowServer(t, 2*time.Second)
 
-	client := NewClient(slowServer.URL)
+	client := NewClient("test", slowServer.URL)
 	client.timeout = 1 * time.Second // Set custom timeout
 	ctx := context.Background()
 
@@ -291,7 +291,7 @@ func TestMultipleWorkingEndpoints(t *testing.T) {
 		"getIdentity": mockResponse2,
 	})
 
-	client := NewClient(server1.URL, server2.URL)
+	client := NewClient("test", server1.URL, server2.URL)
 	ctx := context.Background()
 
 	// Should succeed with the first working server
@@ -302,7 +302,7 @@ func TestMultipleWorkingEndpoints(t *testing.T) {
 
 func TestEmptyURLs(t *testing.T) {
 	// Test creating client with no URLs
-	client := NewClient()
+	client := NewClient("test")
 	assert.NotNil(t, client)
 	assert.Len(t, client.clients, 0)
 }
@@ -310,7 +310,7 @@ func TestEmptyURLs(t *testing.T) {
 func TestInvalidURL(t *testing.T) {
 	// Test with invalid URL - this should still create the client
 	// but the actual RPC calls will fail
-	client := NewClient("invalid-url")
+	client := NewClient("test", "invalid-url")
 	assert.NotNil(t, client)
 	assert.Len(t, client.clients, 1)
 	assert.Contains(t, client.clients, "invalid-url")
@@ -325,7 +325,7 @@ func TestContextCancellation(t *testing.T) {
 	// Create a slow server
 	slowServer := mockSlowServer(t, 5*time.Second)
 
-	client := NewClient(slowServer.URL)
+	client := NewClient("test", slowServer.URL)
 	ctx, cancel := context.WithCancel(context.Background())
 
 	// Cancel the context immediately
@@ -368,7 +368,7 @@ func TestComplexClusterNodesResponse(t *testing.T) {
 		"getClusterNodes": mockResponse,
 	})
 
-	client := NewClient(server.URL)
+	client := NewClient("test", server.URL)
 	ctx := context.Background()
 
 	result, err := client.GetClusterNodes(ctx)
@@ -432,7 +432,7 @@ func TestGetURLsToTry(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client := NewClient(tt.urls...)
+			client := NewClient("test", tt.urls...)
 			client.lastSuccessfulURL = tt.lastSuccessfulURL
 
 			result := client.getURLsToTry()
@@ -475,7 +475,7 @@ func TestLastSuccessfulURLAvoidance(t *testing.T) {
 	}
 
 	// Create client with multiple URLs
-	client := NewClient(urls...)
+	client := NewClient("test", urls...)
 
 	// Make several calls and verify it avoids the last successful URL initially
 	ctx := context.Background()
@@ -549,7 +549,7 @@ func TestLastSuccessfulURLWithFailures(t *testing.T) {
 	}
 
 	// Create client with multiple URLs
-	client := NewClient(urls...)
+	client := NewClient("test", urls...)
 
 	// Make 6 calls - should avoid lastSuccessfulURL but server 0 always fails
 	ctx := context.Background()


### PR DESCRIPTION
- set self to passive only when failover deemed required and leaderless threshold exceeded
- inconsequential logging update
- tidy up reporting of rpc errors
- sync HA state checking across all nodes